### PR TITLE
Bumping to mongoid 5

### DIFF
--- a/lib/mongoid/relations_dirty_tracking.rb
+++ b/lib/mongoid/relations_dirty_tracking.rb
@@ -17,7 +17,7 @@ module Mongoid
       cattr_accessor :relations_dirty_tracking_options
       self.relations_dirty_tracking_options = { only: [], except: ['versions'] }
 
-      if self.include? Mongoid::Versioning
+      if (defined? Mongoid::Versioning) && (self.include? Mongoid::Versioning)
         include Mongoid::RelationsDirtyTracking::Versioning
       end
     end
@@ -73,7 +73,7 @@ module Mongoid
         elsif meta.relation == Mongoid::Relations::Referenced::ManyToMany
           send("#{rel_name.singularize}_ids").map {|id| { "#{meta.primary_key}" => id } }
         elsif meta.relation == Mongoid::Relations::Referenced::In
-          send(meta.foreign_key) && { "#{meta.foreign_key}" => send(meta.foreign_key)}
+          send(meta.name) && { "#{meta.foreign_key}" => send(meta.foreign_key)}
         end
       end
       values

--- a/lib/mongoid/relations_dirty_tracking.rb
+++ b/lib/mongoid/relations_dirty_tracking.rb
@@ -11,8 +11,8 @@ module Mongoid
       after_initialize  :store_relations_shadow
       after_save        :store_relations_shadow
 
-      alias_method_chain :changes, :relations
-      alias_method_chain :changed?, :relations
+      #alias_method_chain :changes, :relations
+      #alias_method_chain :changed?, :relations
 
       cattr_accessor :relations_dirty_tracking_options
       self.relations_dirty_tracking_options = { only: [], except: ['versions'] }
@@ -49,12 +49,12 @@ module Mongoid
 
 
     def changed_with_relations?
-      changed_without_relations? or relations_changed?
+      changed? or relations_changed?
     end
 
 
     def changes_with_relations
-      (changes_without_relations || {}).merge relation_changes
+      (changes || {}).merge relation_changes
     end
 
 

--- a/mongoid_relations_dirty_tracking.gemspec
+++ b/mongoid_relations_dirty_tracking.gemspec
@@ -11,8 +11,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://github.com/versative/relations_dirty_tracking"
   spec.license       = "MIT"
 
-  spec.add_runtime_dependency 'activesupport', '~> 3.0'
-  spec.add_runtime_dependency 'mongoid', '>= 3.1.0', '< 4.0'
+  spec.add_runtime_dependency 'activesupport', '~> 4.0'
+  spec.add_runtime_dependency 'mongoid', '~>5.0'
+  spec.add_runtime_dependency 'rspec-its'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/spec/lib/mongoid/relations_dirty_tracking_spec.rb
+++ b/spec/lib/mongoid/relations_dirty_tracking_spec.rb
@@ -69,7 +69,7 @@ describe Mongoid::RelationsDirtyTracking do
 
       describe "#relation_changes" do
         it "returns array with differences" do
-          old_attributes = @embedded_doc.attributes.clone.delete_if {|key, val| key == "title" }
+          old_attributes = @embedded_doc.attributes.clone.delete_if {|key, _| key == "title" }
           expect(subject.relation_changes['one_document']).to eq([old_attributes, @embedded_doc.attributes])
         end
       end

--- a/spec/lib/mongoid/relations_dirty_tracking_spec.rb
+++ b/spec/lib/mongoid/relations_dirty_tracking_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe Mongoid::RelationsDirtyTracking do
   subject { TestDocument.create }
 
-  its(:changed?)                { should be_false }
+  its(:changed_with_relations?)                { should be_false }
   its(:children_changed?)       { should be_false }
   its(:relations_changed?)      { should be_false }
   its(:changed_with_relations?) { should be_false }
@@ -17,7 +17,7 @@ describe Mongoid::RelationsDirtyTracking do
         subject.one_document = @embedded_doc
       end
 
-      its(:changed?)                { should be_true }
+      its(:changed_with_relations?)                { should be_true }
       its(:children_changed?)       { should be_false }
       its(:relations_changed?)      { should be_true }
       its(:changed_with_relations?) { should be_true }
@@ -39,7 +39,7 @@ describe Mongoid::RelationsDirtyTracking do
         subject.one_document = nil
       end
 
-      its(:changed?)                { should be_true }
+      its(:changed_with_relations?)                { should be_true }
       its(:children_changed?)       { should be_false }
       its(:relations_changed?)      { should be_true }
       its(:changed_with_relations?) { should be_true }
@@ -61,7 +61,7 @@ describe Mongoid::RelationsDirtyTracking do
         subject.one_document.title = 'foobar'
       end
 
-      its(:changed?)                { should be_true }
+      its(:changed_with_relations?)                { should be_true }
       its(:children_changed?)       { should be_true }
       its(:relations_changed?)       { should be_true }
       its(:changed_with_relations?)  { should be_true }
@@ -75,6 +75,22 @@ describe Mongoid::RelationsDirtyTracking do
       end
     end
 
+    context "when saving attribute of embedded document" do
+      before :each do
+        @embedded_doc = TestEmbeddedDocument.new
+        subject.one_document = @embedded_doc
+        subject.save!
+        subject.one_document.title = 'foobar'
+        subject.save!
+      end
+
+      describe "#relation_changes" do
+        it "document is saved, shouldnt" do
+          expect(TestDocument.first.one_document).to eq @embedded_doc
+        end
+      end
+    end
+
     context "when just updated_at is changed on embedded document" do
       before :each do
         embedded_doc = Class.new(TestEmbeddedDocument) { include Mongoid::Timestamps }.new
@@ -82,7 +98,7 @@ describe Mongoid::RelationsDirtyTracking do
         subject.save!
         embedded_doc.updated_at = Time.now
       end
-      its(:changed?) { should be_false }
+      its(:changed_with_relations?) { should be_false }
     end
   end
 
@@ -93,7 +109,7 @@ describe Mongoid::RelationsDirtyTracking do
         subject.many_documents << @embedded_doc
       end
 
-      its(:changed?)                { should be_true }
+      its(:changed_with_relations?)                { should be_true }
       its(:children_changed?)       { should be_false }
       its(:relations_changed?)       { should be_true }
       its(:changed_with_relations?)  { should be_true }
@@ -115,7 +131,7 @@ describe Mongoid::RelationsDirtyTracking do
         subject.many_documents.delete @embedded_doc
       end
 
-      its(:changed?)                { should be_true }
+      its(:changed_with_relations?)                { should be_true }
       its(:children_changed?)       { should be_false }
       its(:relations_changed?)      { should be_true }
       its(:changed_with_relations?) { should be_true }
@@ -137,7 +153,7 @@ describe Mongoid::RelationsDirtyTracking do
         subject.one_related = @related_doc
       end
 
-      its(:changed?)                { should be_true }
+      its(:changed_with_relations?)                { should be_true }
       its(:children_changed?)       { should be_false }
       its(:relations_changed?)      { should be_true }
       its(:changed_with_relations?) { should be_true }
@@ -158,7 +174,7 @@ describe Mongoid::RelationsDirtyTracking do
         subject.one_related = nil
       end
 
-      its(:changed?)                { should be_true }
+      its(:changed_with_relations?)                { should be_true }
       its(:children_changed?)       { should be_false }
       its(:relations_changed?)      { should be_true }
       its(:changed_with_relations?) { should be_true }
@@ -179,7 +195,7 @@ describe Mongoid::RelationsDirtyTracking do
         subject.one_related = @another_related_doc = TestRelatedDocument.new
       end
 
-      its(:changed?)                { should be_true }
+      its(:changed_with_relations?)                { should be_true }
       its(:children_changed?)       { should be_false }
       its(:relations_changed?)      { should be_true }
       its(:changed_with_relations?) { should be_true }
@@ -200,7 +216,7 @@ describe Mongoid::RelationsDirtyTracking do
         subject.one_related.title = "New title"
       end
 
-      its(:changed?)                { should be_false }
+      its(:changed_with_relations?)                { should be_false }
       its(:children_changed?)       { should be_false }
       its(:relations_changed?)      { should be_false }
       its(:changed_with_relations?) { should be_false }
@@ -216,7 +232,7 @@ describe Mongoid::RelationsDirtyTracking do
         subject.many_related << @related_doc
       end
 
-      its(:changed?)                { should be_true }
+      its(:changed_with_relations?)                { should be_true }
       its(:children_changed?)       { should be_false }
       its(:relations_changed?)      { should be_true }
       its(:changed_with_relations?) { should be_true }
@@ -237,7 +253,7 @@ describe Mongoid::RelationsDirtyTracking do
         subject.many_related.delete  @related_doc
       end
 
-      its(:changed?)                { should be_true }
+      its(:changed_with_relations?)                { should be_true }
       its(:children_changed?)       { should be_false }
       its(:relations_changed?)      { should be_true }
       its(:changed_with_relations?) { should be_true }
@@ -259,7 +275,7 @@ describe Mongoid::RelationsDirtyTracking do
         subject.many_to_many_related << @related_doc
       end
 
-      its(:changed?)                { should be_true }
+      its(:changed_with_relations?)                { should be_true }
       its(:children_changed?)       { should be_false }
       its(:relations_changed?)      { should be_true }
       its(:changed_with_relations?) { should be_true }
@@ -280,7 +296,7 @@ describe Mongoid::RelationsDirtyTracking do
         subject.many_to_many_related.delete  @related_doc
       end
 
-      its(:changed?)                { should be_true }
+      its(:changed_with_relations?)                { should be_true }
       its(:children_changed?)       { should be_false }
       its(:relations_changed?)      { should be_true }
       its(:changed_with_relations?) { should be_true }
@@ -304,7 +320,7 @@ describe Mongoid::RelationsDirtyTracking do
         subject.test_document = @doc
       end
 
-      its(:changed?)                { should be_true }
+      its(:changed_with_relations?)                { should be_true }
       its(:children_changed?)       { should be_false }
       its(:relations_changed?)      { should be_true }
       its(:changed_with_relations?) { should be_true }
@@ -325,7 +341,7 @@ describe Mongoid::RelationsDirtyTracking do
         subject.test_document = nil
       end
 
-      its(:changed?)                { should be_true }
+      its(:changed_with_relations?)                { should be_true }
       its(:children_changed?)       { should be_false }
       its(:relations_changed?)      { should be_true }
       its(:changed_with_relations?) { should be_true }


### PR DESCRIPTION
Pull request to add compatibility to Mongoid 5.

Changes: 
- Since Mongoid 4, Versioning is not available out of the box, so I had to add a check before including it.
- Mongoid 5 complained about using the foreign_key id on has_\* relations. So I changed it to send the related model's name instead (which is the standard way of doing it on Mongoid 5). This might break older versions.

All tests are passing (once again, using Mongoid 5. I haven't used older versions). Is there an easy way to test all Mongoid versions?
